### PR TITLE
Initial version of an examples collection

### DIFF
--- a/client/app/examples.html
+++ b/client/app/examples.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="sprotty/sprotty.css">
+	<link rel="stylesheet" href="diagram.css">
+    <style>
+        body {
+            min-height: 100vh;
+        }
+		svg {
+			width: 100%;
+			height: 100%;
+		}
+        .sidebar-heading {
+            font-size: .75rem;
+            /* text-transform: uppercase; */
+        }
+        .sidebar-link {
+            font-size: .9rem;
+        }
+        .vh-50 {
+            height: 50vh!important;
+        }
+        #title {
+            font-size: 1.9rem;
+            font-weight: 300;
+            line-height: 1.2;
+        }
+        #title-small {
+            font-size: 70%;
+            font-weight: 100;
+        }
+	</style>
+</head>
+<body class="d-flex flex-column">
+    <nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
+        <a class="navbar-brand w-100" href="index.html">ELK Graph Viewers</a>
+        <div class="w-100 text-center">
+             <span class="navbar-brand mb-0 h1">Examples</span>
+        </div>
+        <div class="row w-100">
+        </div>
+    </nav>
+    
+    <div class="container-fluid flex-fill d-flex border-top">
+        <div class="row flex-fill">
+            <div class="col-md-2 d-none d-md-block sidebar border-right bg-light">
+                <ul id="toc" class="nav flex-column"></ul>
+            </div>
+            <div class="col pt-4">
+                <div class="row flex-fill"> <!--  -->
+                    <div class="col w-50 p-1">
+                        <div id="example-graph" class="vh-50"></div>
+                    </div>
+                    <div class="col w-50 p-1">
+                        <div id="sprotty" class="vh-50"></div>
+                    </div>
+                </div>
+                <div class="row flex-fill justify-content-center border-top m-2 pt-2">
+                    <div class="col-md-6 p-1 justify-content-center">
+                        <h4><small id="title-small" class="text-muted"></small><br /><span id="title"></span></h4>
+                        <div id="example-description" class="text-left"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="footer border-top p-3">
+        <div class="container-fluid d-flex">
+            <div class="flex-grow-1 text-right">
+                Powered by <a href="https://github.com/eclipse/sprotty">Sprotty</a>,
+                <a href="https://www.eclipse.org/elk/">ELK</a>,
+                and <a href="https://microsoft.github.io/monaco-editor/">Monaco Editor</a>.
+                <a href="https://github.com/kieler/elkgraph-web">EGW</a> commit 7ae3879
+            </div>
+        </div>
+    </footer>
+
+    <script src="vs/loader.js"></script>
+    <script src="examples.bundle.js"></script>
+	<script src="jquery/jquery.slim.min.js"></script>
+    <script src="bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -47,7 +47,7 @@
                         </p>
                         <a href="elkgraph.html" class="stretched-link"></a>
                     </div>
-                </div> 
+                </div>
             </div>
             <div class="col-lg-6 text-center">
                 <div class="card">
@@ -65,7 +65,29 @@
                         </p>
                         <a href="json.html" class="stretched-link"></a>
                     </div>
-                </div> 
+                </div>
+            </div>
+        </div>
+
+        <div class="row justify-content-md-center mt-5">
+            <div class="col-lg-6 text-center">
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="card-title">Examples</h3>
+                        <p class="card-text">
+                            An annotated collection of example graphs.
+                            Their main purpose is to illustrate
+                            various configuration possibilities,
+                            in particular those that are often-used.
+                        </p>
+                        <p>
+                            The source of the examples can be found in ELK's
+                            <a href="https://github.com/eclipse/elk-models" class="nestedLink">models repository</a>.
+                            Pull-requests with concise and new examples are very welcome.
+                        </p>
+                        <a href="examples.html" class="stretched-link"></a>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -87,7 +109,7 @@
                             </p>
                             <a href="models.html" class="stretched-link"></a>
                         </div>
-                    </div> 
+                    </div>
                 </div>
             <div class="col-lg-6 text-center">
                 <div class="card">
@@ -96,7 +118,7 @@
                         <p class="card-text">
                             A side-by-side view of two graph formats.
                             Allows to interactively convert one graph format into another.
-                            It's possible to invoke the conversion programmatically, 
+                            It's possible to invoke the conversion programmatically,
                             see the site for details.
                         </p>
                         <p class="card-text">
@@ -107,10 +129,10 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="row justify-content-md-center mt-4 mb-4"><div class="col-md-8">
             <div class="row text-center m-2 mb-4">
-                <a href="https://github.com/kieler/elkgraph-web" class="text-center btn btn-success mx-auto">View source on GitHub</a> 
+                <a href="https://github.com/kieler/elkgraph-web" class="text-center btn btn-success mx-auto">View source on GitHub</a>
             </div>
             <div class="card panel-default">
                 <div class="card-body">

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,8 @@
   "scripts": {
     "compile": "tsc",
     "clean": "rimraf lib app/bootstrap app/jquery app/sprotty app/vs app/*.bundle.js app/*.bundle.js.map",
-    "build": "yarn compile && webpack --env.production",
+    "copy:examples": "mkdir -p lib/examples/content/ && cp -r src/examples/content/ lib/examples/",
+    "build": "yarn copy:examples && yarn compile && webpack --env.production",
     "build:dev": "yarn compile && webpack",
     "watch": "tsc-watch --onSuccess webpack"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "monaco-editor-core": "^0.14.6",
     "monaco-languageclient": "^0.9.0",
     "reconnecting-websocket": "^4.1.10",
+    "showdown": "^1.9.1",
     "sprotty": "^0.8.0",
     "vscode-ws-jsonrpc": "^0.0.2-1"
   },
@@ -35,12 +36,12 @@
     "umd-compat-loader": "^2.1.1",
     "webpack": "^3.12.0"
   },
-  "resolutions": { 
+  "resolutions": {
     "**/**/kind-of": "^6.0.3",
     "**/**/lodash": "^4.17.12",
     "**/**/mem": "^4.0.0",
     "**/**/minimist": "^1.2.3",
-    "**/**/serialize-javascript": "^2.1.1", 
+    "**/**/serialize-javascript": "^2.1.1",
     "**/**/set-value": "^3.0.2"
   },
   "scripts": {

--- a/client/src/common/creators.ts
+++ b/client/src/common/creators.ts
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import { Container } from 'inversify';
+import { CloseAction, createConnection, ErrorAction, MonacoLanguageClient, MonacoServices } from 'monaco-languageclient';
+import ReconnectingWebSocket from 'reconnecting-websocket';
+import { createRandomId, IActionDispatcher, TYPES } from 'sprotty';
+import { listen, MessageConnection } from 'vscode-ws-jsonrpc';
+import createContainer from '../sprotty-config';
+import { LanguageDiagramServer } from './language-diagram-server';
+
+
+export function createSprottyViewer(requiresActionDispatcher = false): [Container, LanguageDiagramServer, IActionDispatcher] {
+    const sprottyContainer = createContainer();
+    sprottyContainer.bind(TYPES.ModelSource).to(LanguageDiagramServer).inSingletonScope();
+
+    const diagramServer = sprottyContainer.get<LanguageDiagramServer>(TYPES.ModelSource);
+    diagramServer.clientId = 'sprotty';
+
+    const actionDispatcher = sprottyContainer.get<IActionDispatcher>(TYPES.IActionDispatcher);
+
+    return [sprottyContainer, diagramServer, actionDispatcher];
+}
+
+
+
+export function createMonacoEditor(divId: string, modelExt: string = "elkt", modelName: string = "") {
+    // Create Monaco editor
+    const modelUri = `inmemory:/${createRandomId(24)}.${modelExt}`;
+    const editor = monaco.editor.create(document.getElementById(divId)!, {
+        model: monaco.editor.createModel(modelName, modelExt, monaco.Uri.parse(modelUri))
+    });
+    editor.updateOptions({
+        minimap: { enabled: false }
+    });
+    // Resize the monaco editor upon window resize.
+    // There's also an option 'automaticLayout: true' that could be passed to above 'create' method,
+    // however, this cyclically checks the current state and thus is less performant. 
+    window.onresize = () => editor.layout();
+    MonacoServices.install(editor);
+
+    return editor;
+}
+
+
+export function openWebSocketElkGraph(diagramServer: LanguageDiagramServer) {
+
+    const socketUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/elkgraph`;
+    const socketOptions = {
+        maxReconnectionDelay: 10000,
+        minReconnectionDelay: 1000,
+        reconnectionDelayGrowFactor: 1.3,
+        connectionTimeout: 10000,
+        maxRetries: 20,
+        debug: false
+    };
+    const webSocket = new ReconnectingWebSocket(socketUrl, [], socketOptions);
+    listen({
+        webSocket: webSocket as any as WebSocket,
+        onConnection: connection => {
+            const languageClient = createElkLanguageClient(diagramServer, connection)
+            const disposable = languageClient.start()
+            connection.onClose(() => {
+                diagramServer.disconnect()
+                disposable.dispose()
+            })
+        }
+    });
+}
+
+function createElkLanguageClient(diagramServer: LanguageDiagramServer, messageConnection: MessageConnection): MonacoLanguageClient {
+    return new MonacoLanguageClient({
+        name: 'ELK Graph Language Client',
+        clientOptions: {
+            documentSelector: ['elkt'],
+            // Disable the default error handler
+            errorHandler: {
+                error: () => ErrorAction.Continue,
+                closed: () => CloseAction.DoNotRestart
+            }
+        },
+        // Create a language client connection from the JSON RPC connection on demand
+        connectionProvider: {
+            get: (errorHandler, closeHandler) => {
+                const connection = createConnection(messageConnection, errorHandler, closeHandler)
+                diagramServer.listen(connection)
+                return Promise.resolve(connection)
+            }
+        }
+    });
+}

--- a/client/src/common/elkt-language.ts
+++ b/client/src/common/elkt-language.ts
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+monaco.languages.register({
+    id: 'elkt',
+    extensions: ['.elkt']
+});
+
+monaco.languages.setLanguageConfiguration('elkt', {
+    comments: {
+        lineComment: "//",
+        blockComment: ['/*', '*/']
+    },
+    brackets: [['{', '}'], ['[', ']']],
+    autoClosingPairs: [
+        {
+            open: '{',
+            close: '}'
+        },
+        {
+            open: '[',
+            close: ']'
+        }]
+});
+    
+monaco.languages.setMonarchTokensProvider('elkt', <any>{
+    keywords: [
+        'graph', 'node', 'label', 'port', 'edge', 'layout', 'position', 'size', 'incoming', 'outgoing',
+        'start', 'end', 'bends', 'section', 'true', 'false'
+    ],
+
+    typeKeywords: [],
+
+    operators: [],
+
+    symbols: /[=><!~?:&|+\-*\/\^%]+/,
+    escapes: /\\(?:[btnfru\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+    tokenizer: {
+        root: [
+            // Identifiers and keywords
+            [/[a-z_$][\w$]*/, {
+                cases: {
+                    '@typeKeywords': 'keyword',
+                    '@keywords': 'keyword',
+                    '@default': 'identifier'
+                }
+            }],
+
+            // Whitespace
+            { include: '@whitespace' },
+
+            // Delimiters and operators
+            [/[{}()\[\]]/, '@brackets'],
+            [/[<>](?!@symbols)/, '@brackets'],
+            [/@symbols/, {
+                cases: {
+                    '@operators': 'operator',
+                    '@default': ''
+                }
+            }]
+        ],
+
+        whitespace: [
+            [/[ \t\r\n]+/, 'white'],
+            [/\/\*/, 'comment', '@comment'],
+            [/\/\/.*$/, 'comment'],
+        ],
+
+        comment: [
+            [/[^\/*]+/, 'comment'],
+            [/\/\*/, 'comment.invalid'],
+            ["\\*/", 'comment', '@pop'],
+            [/[\/*]/, 'comment']
+        ],
+
+        string: [
+            [/[^\\"]+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/"/, 'string', '@pop']
+        ],
+    },
+});

--- a/client/src/common/language-diagram-server.ts
+++ b/client/src/common/language-diagram-server.ts
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+import { IConnection } from "monaco-languageclient/lib/connection";
+import { DiagramServer, ActionMessage, ActionHandlerRegistry, Action } from "sprotty";
+
+const DIAGRAM_ENDPOINT_NOTIFICATION = 'diagram/accept';
+const DID_CLOSE_NOTIFICATION = 'diagram/didClose';
+
+export class ChangeLayoutVersionAction implements Action {
+    static readonly KIND = 'versionChange';
+    readonly kind = ChangeLayoutVersionAction.KIND;
+
+    constructor(public readonly version?: string) {}
+}
+
+export class LanguageDiagramServer extends DiagramServer {
+    protected connection?: IConnection;
+
+    initialize(registry: ActionHandlerRegistry): void {
+        super.initialize(registry);
+        registry.register(ChangeLayoutVersionAction.KIND, this);
+    }
+
+    listen(connection: IConnection) {
+        connection.onNotification(DIAGRAM_ENDPOINT_NOTIFICATION, (message: ActionMessage) => {
+            this.messageReceived(message)
+        });
+        this.connection = connection;
+    }
+
+    disconnect() {
+        if (this.connection !== undefined) {
+            this.connection.sendNotification(DID_CLOSE_NOTIFICATION, this.clientId);
+            this.connection = undefined;
+        }
+    }
+
+    protected sendMessage(message: ActionMessage): void {
+        if (this.connection !== undefined) {
+            this.connection.sendNotification(DIAGRAM_ENDPOINT_NOTIFICATION, message);
+        }
+    }
+}

--- a/client/src/common/url-parameters.ts
+++ b/client/src/common/url-parameters.ts
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import ICodeEditor = monaco.editor.ICodeEditor;
+import IModelContentChangedEvent = monaco.editor.IModelContentChangedEvent;
+
+export function getParameters(): {[key: string]: string} {
+    let search = window.location.search.substring(1);
+    const result = {};
+    while (search.length > 0) {
+        const nextParamIndex = search.indexOf('&');
+        let param: string;
+        if (nextParamIndex < 0) {
+            param = search;
+            search = '';
+        } else {
+            param = search.substring(0, nextParamIndex);
+            search = search.substring(nextParamIndex + 1);
+        }
+        const valueIndex = param.indexOf('=');
+        if (valueIndex > 0 && valueIndex < param.length - 1) {
+            result[param.substring(0, valueIndex)] = param.substring(valueIndex + 1);
+        }
+    }
+    return result;
+}
+
+export function setupModelLink(editor: ICodeEditor, getParameters: (event: IModelContentChangedEvent)=>{[key: string]: string}) {
+    let contentChangeTimeout: number;
+    const listener = event => {
+        if (contentChangeTimeout !== undefined) {
+            window.clearTimeout(contentChangeTimeout);
+        }
+        contentChangeTimeout = window.setTimeout(() => {
+            const anchor = document.getElementById('model-link');
+            if (anchor !== null) {
+                const parameters = getParameters(event);
+                const newHref = assembleHref(parameters);
+                anchor.setAttribute('href', newHref);
+            }
+        }, 400);
+    }
+    editor.onDidChangeModelContent(listener);
+    listener({});
+}
+
+export function assembleHref(parameters: { [key: string]: string }): string {
+    let newHref = window.location.href;
+    const queryIndex = newHref.indexOf('?');
+    if (queryIndex > 0)
+        newHref = newHref.substring(0, queryIndex);
+    newHref += combineParameters(parameters);
+    return newHref;
+}
+
+export function combineParameters(parameters: { [key: string]: string }): string {
+    let result = '';
+    let i = 0;
+    for (let param in parameters) {
+        result += `${i === 0 ? '?' : '&'}${param}=${parameters[param]}`;
+        i++;
+    }
+    return result;
+}

--- a/client/src/common/util.ts
+++ b/client/src/common/util.ts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+export function groupBy<T>(iterable: T[], keyFun: (e) => string): { [key: string]: T[] } {
+    return iterable.reduce((result, element) => {
+        const key = keyFun(element);
+        if (result[key] === undefined) {
+            result[key] = [];
+        }
+        result[key].push(element);
+        return result;
+    }, {})
+}

--- a/client/src/examples/content/direction.elkt
+++ b/client/src/examples/content/direction.elkt
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+General > Direction
+
+// elkex:label
+Basics
+
+// elkex:doc
+The example illustrates how different layout directions can be set.
+*/
+
+// elkex:graph
+node leftToRight {
+    elk.direction: RIGHT
+    nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+    node n1
+    node n2
+    edge n1->n2
+    label "leftToRight"
+}
+
+node topToBottom {
+    elk.direction: DOWN
+    nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+    node n1
+    node n2
+    edge n1->n2
+    label "topToBottom"
+}
+
+node rightToLeft {
+    elk.direction: LEFT
+    nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+    node n1
+    node n2
+    edge n1->n2
+    label "rightToLeft"
+}
+
+node bottomToTop {
+    elk.direction: UP
+    nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+    node n1
+    node n2
+    edge n1->n2
+    label "bottomToTop"
+}

--- a/client/src/examples/content/edges/insideSelfLoops.elkt
+++ b/client/src/examples/content/edges/insideSelfLoops.elkt
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Edges > Selfloops
+
+// elkex:label
+Inside Selfloop
+
+// elkex:doc
+The example illustrates how a node can have a usual selfloop 
+as well as an _inside selfloop_. 
+
+Note that as soon as a node holds an inside selfloop, 
+the algorithm internally turns the node into a hierarchical node 
+even if it has no children. 
+As a consequence it is not possible to set the node's size 
+the usual way. One has to use the `nodeSize.minimum` and `nodeSize.constraints` options instead 
+as illustrated here.
+*/
+
+// elkex:graph
+node parent {
+    insideSelfLoops.activate: true
+    portConstraints: FIXED_SIDE
+    port p1 { side: WEST }
+    port p2 { side: EAST }
+}
+edge parent.p1 -> parent.p2
+edge parent.p1 -> parent.p2 {
+    insideSelfLoops.yo: true
+}
+
+node parentWithSize {
+    layout [ size: 200, 100 ]
+    nodeSize.minimum: "100, 50"
+    nodeSize.constraints: MINIMUM_SIZE
+    insideSelfLoops.activate: true
+    portConstraints: FIXED_SIDE
+    port p1 { side: WEST }
+    port p2 { side: EAST }
+}
+edge parentWithSize.p1 -> parentWithSize.p2
+edge parentWithSize.p1 -> parentWithSize.p2 {
+    insideSelfLoops.yo: true
+}

--- a/client/src/examples/content/hierarchicalEdges.elkt
+++ b/client/src/examples/content/hierarchicalEdges.elkt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Hierarchy > Edges
+
+// elkex:label
+Basics
+
+// elkex:doc
+The example illustrates how `elk.layered` can be configured 
+to support _hierarchical edges_. 
+
+The central layout option is `hierarchyHandling: INCLUDE_CHILDREN`, 
+which changes the behavior of `elk.layered` to work on the whole graph at once 
+instead of processing the content of each hierarchical node in a bottom-up fashion.
+
+Note that hierarchical edges can be modelled manually by adding 
+ports at the boundaries of hierarchical nodes.
+*/
+
+// elkex:graph
+algorithm: elk.layered
+hierarchyHandling: INCLUDE_CHILDREN
+
+node source
+
+node outside {
+    node inside {
+        node n1 
+        node n2
+        edge n1 -> n2
+    }
+}
+
+edge source -> outside.inside.n1

--- a/client/src/examples/content/hierarchicalLayoutMixing.elkt
+++ b/client/src/examples/content/hierarchicalLayoutMixing.elkt
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Hierarchy
+
+// elkex:label
+Mixed Algorithms
+
+// elkex:doc
+The example illustrates how different layout algorithms 
+can be configured for different hierarchical nodes 
+by setting the `algorithm` option for the individual nodes.
+
+It illustrates two further effects. 
+First, while the `hierarchyHandling: INCLUDE_CHILDREN` option
+(which is only available for `elk.layered`) usually results in 
+the whole graph being passed to `elk.layered`, 
+in this case the subgraph starting at `insideOtherLayout` is excluded from 
+this behavior. It is laid out separately. 
+The same behavior can be achieved by explicitly setting `hierarchyHandling: SEPARATE_CHILDREN`,
+which is, for instance, necessary if different layout directions 
+are required - the second effect illustrated here.
+See the options applied to `insideOtherDirection`.
+*/
+
+// elkex:graph
+algorithm: elk.layered
+hierarchyHandling: INCLUDE_CHILDREN
+
+node source
+
+node outside {
+    node inside {
+        node n1 
+        node n2
+        edge n1 -> n2
+    }
+
+    node insideOtherLayout {
+        algorithm: elk.stress
+        desiredEdgeLength: 50
+        elk.padding: "[top=10,left=10,bottom=10,right=10]"
+        node n3
+        node n4
+        node n5
+        edge n3 -> n4
+        edge n4 -> n5
+        edge n5 -> n3
+    }
+
+    node insideOtherDirection {
+        // Note that to activate the different direction, 
+        // hierarchyHandling has to be switched off. 
+        // This also deactivates hierarchical edges for any internals
+        elk.direction: DOWN
+        hierarchyHandling: SEPARATE_CHILDREN
+        node n6
+        node n7
+        edge n6 -> n7
+    }
+}
+
+edge source -> outside.inside.n1

--- a/client/src/examples/content/mixingDirection.elkt
+++ b/client/src/examples/content/mixingDirection.elkt
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+General > Direction
+
+// elkex:label
+Mixed Directions
+
+// elkex:doc
+The example illustrates how different levels of a hierarchical graph
+can be laid out using different layout directions. 
+
+Note that hierarchical edges (edges that cross the boundary of a hierarchical node)
+are not possible in this scenario. See the examples on hierarchical edges for further details.
+*/
+
+// elkex:graph
+node outsideTopToBottom {
+    elk.direction: DOWN
+    nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+    label "topToBottom"
+    
+    node leftToRight {
+        elk.direction: RIGHT
+        nodeLabels.placement: "H_LEFT V_BOTTOM OUTSIDE"
+        node n1
+        node n2
+        edge n1->n2
+        label "leftToRight"
+    }
+    node bottomToTop {
+        elk.direction: UP
+        nodeLabels.placement: "H_LEFT V_TOP OUTSIDE"
+        node n1
+        node n2
+        edge n1->n2
+        label "bottomToTop"
+    }
+    
+    edge bottomToTop -> leftToRight
+}

--- a/client/src/examples/content/nodeLabelPlacement.elkt
+++ b/client/src/examples/content/nodeLabelPlacement.elkt
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Labels > Node
+
+// elkex:label
+Basics
+
+// elkex:doc
+The example illustrates a number of possible node label placement strategies.
+The layout option `nodeLabels.placement` is a combination of three components:
+the vertical alignment, the horizontal alignment, and whether the label should be placed inside or outside of the node.
+Not every combination makes sense though.
+A label placed on the outside cannot be centered in both dimensions, for instance.
+
+The option can either be set for a node or for each label individually.
+
+The layout algorithm computes a position for the top-left corner of the label,
+relative to the top-left corner of the parent node.
+This has to be considered whenever labels are positioned with a different reference point,
+which is the default behavior of SVGs, for instance.
+Additionally note that the layout algorithm is not able to compute the dimensions of a label,
+as it isn't aware of the used font size and font family.
+*/
+
+// elkex:graph
+aspectRatio: 0.1 // Only for presentation purposes
+node N1 {
+	layout [ size: 200, 75 ]
+	label "Main Node Label" {
+        layout [ size: 100, 15 ]
+		nodeLabels.placement: "INSIDE V_TOP H_CENTER"
+	}
+	label "Second Node Label" {
+        layout [ size: 117, 15 ]
+		nodeLabels.placement: "INSIDE V_TOP H_CENTER"
+	}
+	label "Value: 42" {
+        layout [ size: 56, 15 ]
+		nodeLabels.placement: "INSIDE V_BOTTOM H_LEFT"
+	}
+	label "New Value: 73" {
+        layout [ size: 88, 15 ]
+		nodeLabels.placement: "INSIDE V_BOTTOM H_RIGHT"
+	}
+}
+
+node Outside {
+    aspectRatio: 3 // Only for presentation purposes
+    node N2 {
+        layout [ size: 100, 75 ]
+        nodeLabels.placement: "OUTSIDE V_TOP H_LEFT"
+        label "N2" { layout [ size: 17, 15 ] }
+    }
+    node N3 {
+        layout [ size: 100, 75 ]
+        nodeLabels.placement: "OUTSIDE V_TOP H_CENTER"
+        label "N3" { layout [ size: 17, 15 ] }
+    }
+    node N4 {
+        layout [ size: 100, 75 ]
+        nodeLabels.placement: "OUTSIDE H_PRIORITY V_TOP H_LEFT"
+        label "N4" { layout [ size: 17, 15 ] }
+    }
+}
+
+node Inside {
+    aspectRatio: 3 // Only for presentation purposes
+    node N5 {
+        layout [ size: 100, 75 ]
+        nodeLabels.placement: "INSIDE V_TOP H_LEFT"
+        label "N5" { layout [ size: 17, 15 ] }
+    }
+    node N6 {
+        layout [ size: 100, 75 ]
+        nodeLabels.placement: "INSIDE V_TOP H_CENTER"
+        label "N6" { layout [ size: 17, 15 ] }
+    }
+}

--- a/client/src/examples/content/portConstraints.elkt
+++ b/client/src/examples/content/portConstraints.elkt
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Ports > Constraints
+
+// elkex:label
+Basics
+
+// elkex:doc
+The graphs illustrate a number of possibilities to constrain 
+the positions of a node's ports.
+*/
+
+// elkex:graph
+aspectRatio: 0.1 // only for presentation purposes
+node freePorts {
+    node n1 {
+        portConstraints: FREE
+        port p1
+        port p2
+    } 
+    node n2 {
+        portConstraints: FREE
+        port p1
+        port p2
+    }
+    edge n1.p1 -> n2.p1
+    edge n1.p2 -> n2.p2
+}
+
+node fixedSide {
+    node n1 {
+        portConstraints: FIXED_SIDE
+        port p1 { ^port.side: WEST }
+        port p2 { ^port.side: EAST }
+    } 
+    node n2 {
+        portConstraints: FIXED_SIDE
+        port p1 { ^port.side: WEST }
+        port p2 { ^port.side: NORTH }
+    }
+    edge n1.p1 -> n2.p1
+    edge n1.p2 -> n2.p2
+}
+
+node fixedPosition {
+    node n1 {
+        portConstraints: FIXED_POS
+        port p1 { layout [ position: -5, 5 ] }
+        port p2 { layout [ position: 35, 10 ] }
+    } 
+    node n2 {
+        portConstraints: FIXED_SIDE
+        port p1 { layout [ position: 10, -10 ] }
+        port p2 { layout [ position: 15, 40 ] }
+    }
+    edge n1.p1 -> n2.p1
+    edge n1.p2 -> n2.p2
+}

--- a/client/src/examples/content/portLabelsMulti.elkt
+++ b/client/src/examples/content/portLabelsMulti.elkt
@@ -1,0 +1,83 @@
+ /*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/*
+// elkex:category
+Labels > Ports
+
+// elkex:label
+Multiple labels
+
+// elkex:doc
+Demonstrates the placement of multiple labels per port.
+
+#### `INSIDE`
+The labels of eastern ports should be aligned flush-right, the labels of western
+ports should be aligned flush-left.
+
+#### `OUTSIDE`
+The labels of eastern ports should be aligned flush-left, the labels of western
+ports should be aligned flush-right.
+*/
+
+// elkex:graph
+spacing.labelPort: 10
+node Inside {
+	layout [ size: 170, 180 ]
+	nodeLabels.placement: "[H_CENTER, V_BOTTOM, OUTSIDE]"
+	portLabels.placement: INSIDE
+	portConstraints: FIXED_SIDE
+	port west1 {
+		side: WEST
+		label "west1" { layout [ size: 36, 15 ] }
+		label "[0]" { layout [ size: 15, 15 ] }
+	}
+	port west2 {
+		side: WEST
+		label "west2" { layout [ size: 36, 15 ] }
+		label "[13]" { layout [ size: 23, 15 ] }
+	}
+	port east1 {
+		side: EAST
+		label "east1" { layout [ size: 33, 15 ] }
+		label "[23]" { layout [ size: 23, 15 ] }
+	}
+	port east2 {
+		side: EAST
+		label "east2" { layout [ size: 33, 15 ] }
+		label "[42]" { layout [ size: 23, 15 ] }
+	}
+}
+node Outside {
+	layout [ size: 80, 80 ]
+	nodeLabels.placement: "[H_CENTER, V_BOTTOM, OUTSIDE]"
+	portLabels.placement: OUTSIDE
+	portConstraints: FIXED_SIDE
+	port west1 {
+		side: WEST
+		label "west1" { layout [ size: 36, 15 ] }
+		label "[0]" { layout [ size: 15, 15 ] }
+	}
+	port west2 {
+		side: WEST
+		label "west2" { layout [ size: 36, 15 ] }
+		label "[13]" { layout [ size: 23, 15 ] }
+	}
+	port east1 {
+		side: EAST
+		label "east1" { layout [ size: 33, 15 ] }
+		label "[23]" { layout [ size: 23, 15 ] }
+	}
+	port east2 {
+		side: EAST
+		label "east2" { layout [ size: 33, 15 ] }
+		label "[42]" { layout [ size: 23, 15 ] }
+	}
+}

--- a/client/src/examples/elkex-loader.ts
+++ b/client/src/examples/elkex-loader.ts
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+import { ElkExample } from './elkex';
+
+const PATH_REGEX = /.*examples\/content\/(.*)\.elkt/
+
+module.exports = function(source) {
+  // Turn the resource path into a unique ID
+  const resourcePath = <string>(<any>this).resourcePath;
+  const match = PATH_REGEX.exec(resourcePath)
+  // TODO handle error
+  const path = match![1]
+  const example = new ElkExample(path, source);
+  const content = JSON.stringify(example);
+
+  return `module.exports = ${content}`;
+}

--- a/client/src/examples/elkex.ts
+++ b/client/src/examples/elkex.ts
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+import { groupBy } from "../common/util";
+
+export class ElkExample {
+
+    static readonly KEYS: Set<string> = new Set(["graph", "doc", "category", "label"])
+
+    readonly path: string;
+    label: string;
+    graph: string;
+    doc: string;
+    category: string[];
+
+    constructor(path: string, serialized: string) {
+        this.path = path;
+
+        const sections = serialized.split(/\/\/\s*elkex:/)
+        sections.map(s => s.trim())
+            .filter(s => ElkExample.KEYS.has(this.firstWord(s)))
+            .map(s => [this.firstWord(s), this.content(s)])
+            .forEach(pair => {
+                const key = pair[0].trim()
+                let value = pair[1];
+                if (key !== "graph") {
+                    value = this.removeComments(value);
+                }
+                value = value.trim();
+                switch (key) {
+                    case "category":
+                        this[key] = value.split('>').map(s => s.trim());
+                        break;
+                    default:
+                        this[key] = value;
+                }
+            })
+
+        const missingKeys = Array.from(ElkExample.KEYS)
+            .map(k => this[k] === undefined ? k : undefined)
+            .filter(e => e !== undefined);
+        if (missingKeys.length > 0) {
+            throw new Error(`Example specification '${path}' is missing the following elements: ${missingKeys.join(', ')}`);
+        }
+    }
+
+    private removeComments(s: string): string {
+        return s.replace(/^( |\t)*\/\//gm, '')
+            .replace(/\/\*/g, '')
+            .replace(/\*\//g, '')
+    }
+
+    private firstWord(s: string): string {
+        return s.substr(0, this.firstRealWhitespaceOrSymbol(s))
+    }
+
+    private content(s: string): string {
+        return s.substr(this.firstNewlineSymbol(s) + 1, s.length)
+    }
+
+    private firstRealWhitespaceOrSymbol(s: string): number {
+        return s.search(/(\s|\\r|\\n)/);
+    }
+
+    private firstNewlineSymbol(s: string): number {
+        return s.search(/(\r|\n|\\r|\\n)/);
+    }
+
+}
+
+export interface ExampleCategory {
+    name: string;
+    elements: ElkExample[];
+    subCategories: ExampleCategory[];
+}
+
+export function createExampleCategoryTree(examples: ElkExample[], depth: number = 0, name: string = 'root'): ExampleCategory {
+    const grouped = groupBy(examples, e => e.category[depth] || 'current')
+    const subCategories = Object.keys(grouped)
+        .filter(k => k !== 'current')
+        .map(k => createExampleCategoryTree(grouped[k], depth + 1, k))
+    const elements = grouped['current']
+
+    return { name, elements, subCategories }
+}

--- a/client/src/examples/examples.ts
+++ b/client/src/examples/examples.ts
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+import 'reflect-metadata';
+import * as showdown from 'showdown';
+import { createMonacoEditor, createSprottyViewer, openWebSocketElkGraph } from '../common/creators';
+import { getParameters } from "../common/url-parameters";
+import { createExampleCategoryTree, ElkExample, ExampleCategory } from './elkex';
+
+require('../common/elkt-language');
+
+enum HistoryMode {
+    IGNORE, PUSH_STATE, REPLACE_STATE
+}
+
+// - - - - Set up sprotty, monaco, and the websocket - - - -
+const [, diagramServer,] = createSprottyViewer();
+const editor = createMonacoEditor('example-graph');
+editor.updateOptions({ scrollBeyondLastLine: false });
+openWebSocketElkGraph(diagramServer);
+
+// - - - - Showdown markdown parser - - - -
+showdown.setFlavor('github');
+// simpleLineBreaks: false requires at least two line breaks to start a new paragraph
+const showdownConverter = new showdown.Converter({ simpleLineBreaks: false });
+
+// - - - - The document elements we'll be working with - - - - 
+const tocUl = <HTMLUListElement>document.getElementById('toc');
+const descriptionDiv = <HTMLDivElement>document.getElementById('example-description');
+const title = <HTMLElement>document.getElementById('title');
+const titleSmall = <HTMLElement>document.getElementById('title-small');
+
+// - - - - Build the navigation from all available examples - - - -
+const importAll = (r) => r.keys().map(r);
+const allExamples = importAll((<any>require).context('./content/', true, /\.(elkt)$/));
+const categoryTree = createExampleCategoryTree(allExamples);
+createNavigationDepthFirstAlphabetically(categoryTree);
+
+// - - - - Load initial example. - - - -
+const initialExamplePath = ((params) => {
+    // Either the example id passed via the query parameter 'e' or a random example
+    return params.e || allExamples[Math.floor(Math.random() * allExamples.length)].path;
+})(getParameters());
+loadExample(decodeURIComponent(initialExamplePath), HistoryMode.REPLACE_STATE);
+
+window.onpopstate = (event) => {
+    if (event.state !== undefined && event.state.e !== undefined) {
+        loadExample(event.state.e);
+    }
+    return event.preventDefault();
+}
+
+/* - - - - Utility functions - - - - */
+
+function loadExample(examplePath: string, historyMode: HistoryMode = HistoryMode.IGNORE) {
+    try {
+        const example = require(`./content/${examplePath}.elkt`);
+        title.innerText = example.label;
+        titleSmall.innerText = example.category.join(' > ');
+        descriptionDiv.innerHTML = showdownConverter.makeHtml(example.doc);
+        editor.setValue(example.graph);
+        editor.setPosition({ lineNumber: 1, column: 1 });
+        switch (historyMode) {
+            case HistoryMode.PUSH_STATE:
+                window.history.pushState({ e: example.path }, '', `${location.pathname}?e=${encodeURIComponent(example.path)}`)
+                break;
+            case HistoryMode.REPLACE_STATE:
+                window.history.replaceState({ e: example.path }, '');
+                break;
+        }
+    } catch(e) {
+        // TODO it would be nice to have a speaking error.
+        editor.setValue(e.message);
+    }
+}
+
+function createNavigationHeading(name: string, indent: number) {
+    const heading = document.createElement("h6");
+    heading.className = `sidebar-heading text-muted pl-${indent} mt-2 mb-1`;
+    const span = document.createElement("span");
+    span.innerText = name;
+    heading.appendChild(span);
+    return heading;
+}
+
+function createNavigationLink(example: ElkExample, indent: number = 0) {
+    const listElement = document.createElement("li");
+    const link = document.createElement("button");
+    link.type = 'button';
+    link.className = `sidebar-link btn btn-link btn text-left s-m pl-${indent} py-0`;
+    link.innerText = example.label;
+    link.onclick = () => loadExample(example.path, HistoryMode.PUSH_STATE);
+    listElement.appendChild(link);
+    return listElement;
+}
+
+function createNavigationDepthFirstAlphabetically(category: ExampleCategory, indent: number = 0, namePrefix = "") {
+    const name = category.name;
+    if (name != 'root') {
+        tocUl.appendChild(createNavigationHeading(namePrefix + name, indent));
+    }
+    if (category.elements !== undefined) {
+        category.elements.sort((a, b) => a.label.localeCompare(b.label))
+            .forEach(e => tocUl.appendChild(createNavigationLink(e, indent)));
+    }
+    const newPrefix = name != 'root' ? `${namePrefix} ${name} > ` : namePrefix;
+    category.subCategories.sort((a, b) => a.name.localeCompare(b.name))
+        .forEach(c => createNavigationDepthFirstAlphabetically(c, indent + 1, newPrefix));
+}
+

--- a/client/src/examples/main.ts
+++ b/client/src/examples/main.ts
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+window.onload = () => {
+    // Load Monaco code
+    const w = window as any;
+    w.require(['vs/editor/editor.main'], () => {
+        // Load application code
+        require('./examples');
+    });
+};

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -52,7 +52,11 @@ module.exports = async function (env) {
         {
             test: /node_modules[\\|/](vscode-languageserver-types|vscode-uri|jsonc-parser)/,
             use: { loader: 'umd-compat-loader' }
-        }
+        },
+        {
+            test: /\.elkt$/,
+            use: { loader: path.resolve('./lib/examples/elkex-loader.js') }
+        },
     ];
     if (env.production) {
         rules.push({
@@ -70,10 +74,11 @@ module.exports = async function (env) {
 
     return {
         entry: {
+            conversion: path.resolve(buildRoot, 'conversion/main'),
             elkgraph: path.resolve(buildRoot, 'elkgraph/main'),
+            examples: path.resolve(buildRoot, 'examples/main'),
             json: path.resolve(buildRoot, 'json/main'),
             models: path.resolve(buildRoot, 'models/main'),
-            conversion: path.resolve(buildRoot, 'conversion/main'),
         },
         output: {
             filename: '[name].bundle.js',

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -68,6 +68,18 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-styles@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -403,6 +415,11 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -478,6 +495,15 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -490,6 +516,18 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 commander@2.17.x:
   version "2.17.1"
@@ -688,7 +726,7 @@ debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.0.0, decamelize@^1.1.1:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -874,6 +912,11 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -1182,6 +1225,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -1268,6 +1318,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1826,6 +1881,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.3:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -2337,6 +2400,13 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -2344,10 +2414,22 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 pako@~1.0.5:
   version "1.0.10"
@@ -2719,6 +2801,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -2850,6 +2937,13 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+showdown@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.1.tgz#134e148e75cd4623e09c21b0511977d79b5ad0ef"
+  integrity sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==
+  dependencies:
+    yargs "^14.2"
 
 signal-exit@^3.0.0:
   version "3.0.2"
@@ -3082,6 +3176,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string.prototype.trimleft@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
@@ -3132,6 +3235,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -3568,6 +3678,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -3598,12 +3717,37 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^14.2:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
See the screenshot below. The idea is to have a page holding a collection of examples that illustrate how ELK algorithms can be configured. In particular for often-used/requested configuration options. 

The example information (and the left-side navigation) is extracted fully automatically from the description in the included `*.elkt` files. The plan is to move these examples into ELK's models repository in a next step. All that's necessary to add a new example is to push a new `elkt` file then. 

Note that I also moved some parts of the code that is used for multiple demonstrators into a `common` folder. I plan to adjust the other demonstrators after this has been merged. 

![image](https://user-images.githubusercontent.com/7552459/80813134-b59eec00-8bc9-11ea-95db-8bce2f65d14e.png)
