### PR TITLE
Show loading indicators 

### DIFF
--- a/client/src/elkgraph/editor.ts
+++ b/client/src/elkgraph/editor.ts
@@ -20,6 +20,7 @@ import LZString = require('lz-string');
 
 require('./elkt-language');
 
+const loading = document.getElementById('loading-sprotty')!;
 const urlParameters = getParameters();
 
 let initialContent: string;
@@ -46,6 +47,7 @@ const actionDispatcher = sprottyContainer.get<IActionDispatcher>(TYPES.IActionDi
 
 const versionSelect = <HTMLSelectElement>document.getElementById('elk-version');
 versionSelect.onchange = () => {
+    loading.style.display = 'block';
     const selectedVersion = versionSelect.options[versionSelect.selectedIndex].value;
     actionDispatcher.dispatch(new ChangeLayoutVersionAction(selectedVersion));
 }
@@ -79,6 +81,12 @@ const socketOptions = {
     maxRetries: 20,
     debug: false
 };
+
+// TODO a better way would be to hook into the language server's communication 
+//  (i.e. the underlying websocket's) and to react on the corresponding events.
+//  However, I couldn't find an easy way to do so.
+editor.onDidChangeModelContent(() => loading.style.display = 'block');
+
 const webSocket = new ReconnectingWebSocket(socketUrl, [], socketOptions);
 listen({
     webSocket: webSocket as any as WebSocket,

--- a/client/src/elkgraph/elkgraph_template.html
+++ b/client/src/elkgraph/elkgraph_template.html
@@ -16,6 +16,22 @@
 			width: 100%;
 			height: 100%;
 		}
+        .loading {
+            position: absolute;
+            top: 0;
+            right: 0;
+            display: block;
+            border: 8px solid #ddf;
+            border-top: 8px solid #448;
+            border-radius: 50%;
+            width: 30px;
+            height: 30px;
+            animation: spin 2s linear infinite;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
 	</style>
 </head>
 <body class="d-flex flex-column">
@@ -39,10 +55,12 @@
     <div class="container-fluid flex-fill d-flex border-top pt-4">
 		<div class="row flex-fill">
 			<div class="col w-50 p-1 border-right">
-				<div id="monaco-editor" class="h-100" data-input-type="elkt"></div>
+                <div id="monaco-editor" class="h-100" data-input-type="elkt"></div>
+                <div id="loading-editor" class="mx-2 loading"></div>
 			</div>
 			<div class="col w-50 p-1">
-				<div id="sprotty" class="h-100"></div>
+                <div id="sprotty" class="h-100"></div>
+                <div id="loading-sprotty" class="mx-2 loading"></div>
 			</div>
 		</div>
 	</div>

--- a/client/src/elkgraph/language-diagram-server.ts
+++ b/client/src/elkgraph/language-diagram-server.ts
@@ -28,7 +28,8 @@ export class LanguageDiagramServer extends DiagramServer {
 
     listen(connection: IConnection) {
         connection.onNotification(DIAGRAM_ENDPOINT_NOTIFICATION, (message: ActionMessage) => {
-            this.messageReceived(message)
+            this.messageReceived(message);
+            document.getElementById('loading-sprotty')!.style.display = 'none';
         });
         this.connection = connection;
     }

--- a/client/src/elkgraph/main.ts
+++ b/client/src/elkgraph/main.ts
@@ -12,5 +12,6 @@ window.onload = () => {
     w.require(['vs/editor/editor.main'], () => {
         // Load application code
         require('./editor');
+        document.getElementById("loading-editor")!.style.display = 'none';
     });
 };

--- a/client/src/json/editor.ts
+++ b/client/src/json/editor.ts
@@ -17,6 +17,7 @@ import LZString = require('lz-string');
 
 require('./elk-json-language');
 
+const loading = document.getElementById('loading-sprotty')!;
 const urlParameters = getParameters();
 
 let initialContent: string;
@@ -101,6 +102,7 @@ function updateModel() {
 
         // Prepare the elk version selected by the user
         let selectedVersion = versionSelect.options[versionSelect.selectedIndex].value;
+        loading.style.display = 'block';
         retrieveElk(selectedVersion).then(elk => {
             elk.layout(json)
                 .then(g => {
@@ -110,12 +112,14 @@ function updateModel() {
                 .catch(e => {
                     let markers = [ errorToMarker(e) ]
                     monaco.editor.setModelMarkers(editor.getModel(), "", markers)
-                });
+                })
+                .finally(() => loading.style.display = 'none');
         });
 
     } catch (e) {
         let markers = [ errorToMarker(e) ];
         monaco.editor.setModelMarkers(editor.getModel(), "", markers);
+        loading.style.display = 'none';
      }
 }
 

--- a/client/src/json/json_template.html
+++ b/client/src/json/json_template.html
@@ -16,6 +16,22 @@
 			width: 100%;
 			height: 100%;
 		}
+        .loading {
+            position: absolute;
+            top: 0;
+            right: 0;
+            display: block;
+            border: 8px solid #ddf;
+            border-top: 8px solid #448;
+            border-radius: 50%;
+            width: 30px;
+            height: 30px;
+            animation: spin 2s linear infinite;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
 	</style>
 </head>
 <body class="d-flex flex-column">
@@ -43,10 +59,12 @@
     <div class="container-fluid flex-fill d-flex border-top pt-4">
 		<div class="row flex-fill">
 			<div class="col w-50 p-1 border-right">
-				<div id="monaco-editor" class="h-100" data-input-type="json"></div>
+                <div id="monaco-editor" class="h-100" data-input-type="json"></div>
+                <div id="loading-editor" class="mx-2 loading"></div>
 			</div>
 			<div class="col w-50 p-1">
-				<div id="sprotty" class="h-100"></div>
+                <div id="sprotty" class="h-100"></div>
+                <div id="loading-sprotty" class="mx-2 loading"></div>
 			</div>
 		</div>
 	</div>

--- a/client/src/json/main.ts
+++ b/client/src/json/main.ts
@@ -12,5 +12,6 @@ window.onload = () => {
     w.require(['vs/editor/editor.main'], () => {
         // Load application code
         require('./editor');
+        document.getElementById("loading-editor")!.style.display = 'none';
     });
 };


### PR DESCRIPTION
as long as the underlying editor and layouter code is loading. And as long as layout is performed.