### PR TITLE
Added json language server

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -51,7 +51,8 @@
                             Basically,
                             build your own graphs
                             and see what automatic layout does with them.
-                            You can choose out of the following two formats:
+                            You can choose out of the following two formats,
+                            both supporting content&nbsp;assist (<code>Ctrl+Space</code>) and formatting (<code>Shift+Alt+F</code>):
                         </p>
                         <div class="row">
                             <div class="col small border-right">

--- a/client/src/examples/examples.ts
+++ b/client/src/examples/examples.ts
@@ -28,7 +28,12 @@ enum HistoryMode {
 const [, diagramServer, actionDispatcher] = createSprottyViewer();
 const editor = createMonacoEditor('example-graph');
 editor.updateOptions({ scrollBeyondLastLine: false });
-openWebSocketElkGraph(diagramServer);
+openWebSocketElkGraph({
+    endpoint: 'elkgraph',
+    name: 'ELK Graph Language Client',
+    documentSelector: ['elkt'],
+    diagramServer: diagramServer,
+});
 
 // - - - - Showdown markdown parser - - - -
 showdown.setFlavor('github');

--- a/client/src/json/editor.ts
+++ b/client/src/json/editor.ts
@@ -6,10 +6,10 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 import 'reflect-metadata';
-
-import { TYPES, LocalModelSource } from 'sprotty';
-import { getParameters, setupModelLink } from "../url-parameters";
+import { LocalModelSource, TYPES } from 'sprotty';
+import { createMonacoEditor, openWebSocketElkGraph } from '../common/creators';
 import createContainer from '../sprotty-config';
+import { getParameters, setupModelLink } from "../url-parameters";
 import { ElkGraphJsonToSprotty } from './elkgraph-to-sprotty';
 
 import JSON5 = require('json5');
@@ -41,23 +41,13 @@ if (urlParameters.compressedContent !== undefined) {
 }`;
 }
 
-// Create Monaco editor
-monaco.languages.register({
-    id: 'json',
-    extensions: ['.json'],
-    aliases: ['JSON', 'json'],
-    mimetypes: ['application/json'],
+// Create Monaco editor and connect to language server (mainly for content assist)
+const editor = createMonacoEditor('monaco-editor', 'elkj', initialContent);
+openWebSocketElkGraph({
+    endpoint: 'elkgraphjson',
+    name: 'ELK JSON Graph Language Client',
+    documentSelector: ['elkj'],
 });
-const editor = monaco.editor.create(document.getElementById('monaco-editor')!, {
-    model: monaco.editor.createModel(initialContent, 'json', monaco.Uri.parse('inmemory:/model.json'))
-});
-editor.updateOptions({
-    minimap: { enabled: false }
-});
-// Resize the monaco editor upon window resize.
-// There's also an option 'automaticLayout: true' that could be passed to above 'create' method,
-// however, this cyclically checks the current state and thus is less performant. 
-window.onresize = () => editor.layout();
 
 // Create Sprotty viewer
 const sprottyContainer = createContainer();

--- a/client/src/json/elk-json-language.ts
+++ b/client/src/json/elk-json-language.ts
@@ -7,11 +7,11 @@
  *******************************************************************************/
 
 monaco.languages.register({
-    id: 'json',
-    extensions: ['.json']
+    id: 'elkj',
+    extensions: ['.elkj']
 });
 
-monaco.languages.setLanguageConfiguration('json', {
+monaco.languages.setLanguageConfiguration('elkj', {
     comments: {
         lineComment: "//",
         blockComment: ['/*', '*/']
@@ -28,7 +28,7 @@ monaco.languages.setLanguageConfiguration('json', {
         }]
 });
     
-monaco.languages.setMonarchTokensProvider('json', <any>{
+monaco.languages.setMonarchTokensProvider('elkj', <any>{
     keywords: [
         'id', 'children', 'edges', 'ports', 'labels',
         'source', 'sources', 'target', 'targets',

--- a/server/elkgraph-web/build.gradle
+++ b/server/elkgraph-web/build.gradle
@@ -11,6 +11,8 @@
  	
 	implementation "org.eclipse.elk:org.eclipse.elk.graph.text.ide:${versions.elk}"
 	
+	implementation "org.eclipse.elk:org.eclipse.elk.graph.json.text.ide:${versions.elk}"
+	
 	// Latest ELKs (the older releases are defined in the sub-projects)
 	implementation "org.eclipse.elk:org.eclipse.elk.alg.force:${versions.elk}"
     implementation "org.eclipse.elk:org.eclipse.elk.alg.layered:${versions.elk}"

--- a/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ElkGraphLanguageServerSetup.xtend
+++ b/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ElkGraphLanguageServerSetup.xtend
@@ -10,8 +10,10 @@ package de.cau.cs.kieler.elkgraph.web
 import com.google.inject.Guice
 import com.google.inject.Injector
 import javax.websocket.Endpoint
+import org.eclipse.elk.core.data.LayoutMetaDataService
 import org.eclipse.elk.core.util.persistence.ElkGraphResourceFactory
 import org.eclipse.elk.graph.ElkGraphPackage
+import org.eclipse.elk.graph.json.text.ide.ElkGraphJsonIdeSetup
 import org.eclipse.elk.graph.text.ElkGraphRuntimeModule
 import org.eclipse.elk.graph.text.ide.ElkGraphIdeModule
 import org.eclipse.elk.graph.text.ide.ElkGraphIdeSetup
@@ -28,7 +30,6 @@ import org.eclipse.xtext.ide.server.ServerModule
 import org.eclipse.xtext.ide.server.UriExtensions
 import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.xtext.util.Modules2
-import org.eclipse.elk.core.data.LayoutMetaDataService
 
 /**
  * Configuration of global settings, language server Guice module, and language server setup.
@@ -46,6 +47,10 @@ class ElkGraphLanguageServerSetup extends DiagramLanguageServerSetup {
 				Guice.createInjector(Modules2.mixin(new ElkGraphRuntimeModule, new ElkGraphIdeModule, new ElkGraphDiagramModule))
 			}
 		}.createInjectorAndDoEMFRegistration()
+		
+		// Do _not_ use 'doSetup()' here as that wouldn't include the 'ElkGraphJsonIdeModule'
+		// and thus wouldn't bind the proposal provider
+		new ElkGraphJsonIdeSetup().createInjectorAndDoEMFRegistration
 		
 		// Initialize ELKG Graph XMI format
 		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("elkg", new ElkGraphResourceFactory());

--- a/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ServerLauncher.xtend
+++ b/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ServerLauncher.xtend
@@ -22,6 +22,10 @@ import org.eclipse.jetty.util.log.Slf4jLog
 import org.eclipse.jetty.webapp.WebAppContext
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.ide.server.ILanguageServerShutdownAndExitHandler
+import org.eclipse.xtext.ide.server.ServerModule
+import org.eclipse.xtext.resource.IResourceServiceProvider
+import org.eclipse.xtext.util.Modules2
 
 /**
  * Main class for launching the ELK Graph server.
@@ -41,10 +45,19 @@ class ServerLauncher {
 	val String rootPath
 	val ElkGraphLanguageServerSetup setup
 	
-	private def createInjector() {
+	private def createDiagramServerInjector() {
 		val injector = Guice.createInjector(setup.languageServerModule)
 		setup.setupLanguageServer(injector)
 		return injector
+	}
+	
+	private def createLanguageServerInjector() {
+		Guice.createInjector(Modules2.mixin(
+			new ServerModule,
+			[bind(Endpoint).to(LanguageServerEndpoint)], // not really nice to re-use this but hey ...
+			[bind(IResourceServiceProvider.Registry).toProvider(IResourceServiceProvider.Registry.RegistryProvider)],
+			[bind(ILanguageServerShutdownAndExitHandler).to(ILanguageServerShutdownAndExitHandler.NullImpl)]
+		))
 	}
 	
 	def void start() {
@@ -61,24 +74,43 @@ class ServerLauncher {
 		]
 		server.handler = webAppContext
 		
-		// Configure web socket
 		val container = WebSocketServerContainerInitializer.configureContext(webAppContext)
-		val endpointConfigBuilder = ServerEndpointConfig.Builder.create(LanguageServerEndpoint, '/elkgraph')
-		endpointConfigBuilder.configurator(new ServerEndpointConfig.Configurator {
+
+		// Configure web socket to provide access to a diagram server for elkt
+		val diagramServerEndpointConfigBuilder = ServerEndpointConfig.Builder.create(LanguageServerEndpoint,
+			'/elkgraph')
+		diagramServerEndpointConfigBuilder.configurator(new ServerEndpointConfig.Configurator {
 			override <T> getEndpointInstance(Class<T> endpointClass) throws InstantiationException {
-				return createInjector.getInstance(Endpoint) as T
+				return createDiagramServerInjector.getInstance(Endpoint) as T
 			}
 		})
-		container.addEndpoint(endpointConfigBuilder.build())
-		
-		// Define endpoint for format conversions
-        webAppContext.addServlet(new ServletHolder(new HttpServlet {
-            override protected doPost(HttpServletRequest req,
-                HttpServletResponse resp) throws ServletException, IOException {
-                ElkGraphConversions.handleRequest(req, resp)
-            }
-        }), "/conversion")
+		container.addEndpoint(diagramServerEndpointConfigBuilder.build())
 
+		// Configure a second web socket to provide a plain language server for any known xtext language
+		// Two remarks: 
+		//  1) It is probably possible to re-use the diagram server above. However, to avoid any unexpected behavior,
+		//     we separate it. (For instance, during initial tries it looked like a 'ElkGraphDiagramModule' must be added 
+		//     to the injector even for elkj in order to have a functioning content assist.)
+		//  2) The default behavior to load xtext languages using service loaders, i.e. re-binding 
+		//     'IResourceServiceProvider.Registry' causes the diagram server to fail as soon as the language
+		//     server has been used once. It looks like the automated registration is somehow interfering with the 
+		//     existing one (I presume because it re-registers the elkt language without the diagram server parts). 
+		val languageServerEndpointConfigBuilder = ServerEndpointConfig.Builder.create(LanguageServerEndpoint,
+			'/elkgraphjson')
+		languageServerEndpointConfigBuilder.configurator(new ServerEndpointConfig.Configurator {
+			override <T> getEndpointInstance(Class<T> endpointClass) throws InstantiationException {
+				return createLanguageServerInjector.getInstance(Endpoint) as T
+			}
+		})
+		container.addEndpoint(languageServerEndpointConfigBuilder.build())
+
+		// Define endpoint for format conversions
+		webAppContext.addServlet(new ServletHolder(new HttpServlet {
+			override protected doPost(HttpServletRequest req,
+				HttpServletResponse resp) throws ServletException, IOException {
+				ElkGraphConversions.handleRequest(req, resp)
+			}
+		}), "/conversion")
 
 		// Start the server
 		try {


### PR DESCRIPTION
The PR adds content assist and formatting to the interactive json editor. The editor is still usable without any active websocket connection. I.e. diagram layout and generation still happen browser-side. 

If you find time, feel free to leave comments. Otherwise I'll merge within a day or two. 

I left some reasoning in a comment in the `ServerLauncher.xtend`.